### PR TITLE
ci: enforce semi-linear history with a required PR check

### DIFF
--- a/.github/workflows/semi-linear-history.yml
+++ b/.github/workflows/semi-linear-history.yml
@@ -1,0 +1,60 @@
+name: semi-linear-history
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    name: Enforce semi-linear history
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # we need history to inspect commits
+
+      - name: Fetch remote branches
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --no-tags --prune origin +refs/heads/*:refs/remotes/origin/*
+
+      - name: Run semi-linear checks
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          HEAD_REF="${{ github.event.pull_request.head.ref }}"
+
+          echo "Base: $BASE_REF @ $BASE_SHA"
+          echo "Head: $HEAD_REF @ $HEAD_SHA"
+
+          # 1) Ensure the PR is rebased on the CURRENT base tip
+          #    (merge-base must be exactly the base tip)
+          MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          echo "merge-base(base, head) = $MERGE_BASE"
+          if [[ "$MERGE_BASE" != "$BASE_SHA" ]]; then
+            echo "::error::Branch is not rebased on the latest $BASE_REF tip."
+            echo "         Rebase $HEAD_REF onto origin/$BASE_REF (no merges), then push."
+            exit 1
+          fi
+
+          # 2) Ensure the PR branch has NO merge commits since base tip
+          MERGES="$(git rev-list --merges "$BASE_SHA..$HEAD_SHA" || true)"
+          if [[ -n "$MERGES" ]]; then
+            echo "::error::Merge commits detected in $HEAD_REF. Semi-linear policy requires a clean, rebase-only branch."
+            echo "         Please 'git rebase origin/$BASE_REF' instead of merging $BASE_REF into your branch."
+            echo "         Merge commits found:"
+            echo "$MERGES"
+            exit 1
+          fi
+
+          echo "✅ Semi-linear checks passed: head is rebased on base tip and contains no merge commits."


### PR DESCRIPTION
Add a GitHub Actions workflow that validates PR branches are:

* rebased on the current base tip (`merge-base(base, head) == base_sha`)
* free of merge commits since the base tip (`git rev-list --merges base..head` == ∅)

The job fetches full history, inspects the DAG, and emits actionable errors to guide contributors to `git rebase origin/<base>` and push with `--force-with-lease`.

Operational notes:

* Mark this job as a **required status check** in branch protection.
* Keep **Merge commits** enabled, disable **Rebase**/**Squash**.
* Enable **Require branches to be up to date before merging**.

This approximates GitLab’s “semi-linear” mode on GitHub: PR branches stay linear and up to date; each PR lands as a single merge commit on the target branch.