### PR TITLE
fix: replace immediate timeout with signal context

### DIFF
--- a/cmd/bosun/main.go
+++ b/cmd/bosun/main.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/simone-viozzi/bosun/internal/app"
 )
 
 func main() {
-	ctx, cancel := context.WithTimeout(context.Background(), 0) // no timeout by default
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
 	a := app.New()


### PR DESCRIPTION
Replace context.WithTimeout(context.Background(), 0) with signal.NotifyContext to handle SIGINT/SIGTERM signals for graceful shutdown instead of timing out immediately.