### PR TITLE
feat(labels): implement domain types and ports

### DIFF
--- a/internal/domain/labels/types.go
+++ b/internal/domain/labels/types.go
@@ -1,0 +1,24 @@
+package labels
+
+import "time"
+
+type Kind string
+
+const (
+	KindContainer Kind = "container"
+	KindVolume    Kind = "volume"
+	KindNetwork   Kind = "network"
+)
+
+type LabeledEntity struct {
+	Kind   Kind
+	ID     string
+	Name   string
+	Labels map[string]string
+	Meta   map[string]string // e.g., "compose.project", "compose.service", "image", "networks"
+}
+
+type Snapshot struct {
+	Entities []LabeledEntity
+	TakenAt  time.Time
+}

--- a/internal/domain/labels/types_test.go
+++ b/internal/domain/labels/types_test.go
@@ -1,0 +1,40 @@
+package labels
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTypes(t *testing.T) {
+	// Test Kind constants
+	if KindContainer != "container" {
+		t.Errorf("Expected KindContainer to be 'container', got %s", KindContainer)
+	}
+	if KindVolume != "volume" {
+		t.Errorf("Expected KindVolume to be 'volume', got %s", KindVolume)
+	}
+	if KindNetwork != "network" {
+		t.Errorf("Expected KindNetwork to be 'network', got %s", KindNetwork)
+	}
+
+	// Test LabeledEntity
+	entity := LabeledEntity{
+		Kind:   KindContainer,
+		ID:     "test-id",
+		Name:   "test-name",
+		Labels: map[string]string{"key": "value"},
+		Meta:   map[string]string{"project": "test"},
+	}
+	if entity.Kind != KindContainer {
+		t.Errorf("Expected entity.Kind to be KindContainer")
+	}
+
+	// Test Snapshot
+	snapshot := Snapshot{
+		Entities: []LabeledEntity{entity},
+		TakenAt:  time.Now(),
+	}
+	if len(snapshot.Entities) != 1 {
+		t.Errorf("Expected snapshot to have 1 entity")
+	}
+}

--- a/internal/ports/labels.go
+++ b/internal/ports/labels.go
@@ -1,0 +1,17 @@
+package ports
+
+import (
+	"context"
+
+	dlabels "github.com/simone-viozzi/bosun/internal/domain/labels"
+)
+
+type Selector struct {
+	Prefixes       []string
+	IncludeStopped bool
+	ProjectFilter  []string // optional filter by compose project
+}
+
+type LabelSource interface {
+	Snapshot(ctx context.Context, sel Selector) (dlabels.Snapshot, error)
+}

--- a/internal/ports/labels_test.go
+++ b/internal/ports/labels_test.go
@@ -1,0 +1,49 @@
+package ports
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	dlabels "github.com/simone-viozzi/bosun/internal/domain/labels"
+)
+
+// mockLabelSource implements LabelSource for testing
+type mockLabelSource struct{}
+
+func (m *mockLabelSource) Snapshot(ctx context.Context, sel Selector) (dlabels.Snapshot, error) {
+	return dlabels.Snapshot{
+		Entities: []dlabels.LabeledEntity{
+			{
+				Kind:   dlabels.KindContainer,
+				ID:     "test-container",
+				Name:   "test",
+				Labels: map[string]string{"bosun.test": "true"},
+				Meta:   map[string]string{"project": "test"},
+			},
+		},
+		TakenAt: time.Now(),
+	}, nil
+}
+
+func TestInterfaces(t *testing.T) {
+	// Test Selector struct
+	selector := Selector{
+		Prefixes:       []string{"bosun."},
+		IncludeStopped: false,
+		ProjectFilter:  []string{"test"},
+	}
+	if len(selector.Prefixes) != 1 {
+		t.Errorf("Expected selector to have 1 prefix")
+	}
+
+	// Test LabelSource interface
+	var source LabelSource = &mockLabelSource{}
+	snapshot, err := source.Snapshot(context.Background(), selector)
+	if err != nil {
+		t.Errorf("Expected no error from Snapshot, got %v", err)
+	}
+	if len(snapshot.Entities) != 1 {
+		t.Errorf("Expected snapshot to have 1 entity")
+	}
+}


### PR DESCRIPTION
Add domain models and ports for label discovery as per issue #20.

- New package internal/domain/labels with Kind, LabeledEntity, Snapshot types
- New port internal/ports/labels.go with LabelSource interface and Selector struct
- Unit tests compiling against the interfaces

Closes #20