### PR TITLE
feat(dockerlabels): add FilterByPrefixes utility for label discovery

### DIFF
--- a/internal/adapters/dockerlabels/filters.go
+++ b/internal/adapters/dockerlabels/filters.go
@@ -1,0 +1,27 @@
+package dockerlabels
+
+import "strings"
+
+// FilterByPrefixes filters a map of labels by allowed prefixes and drops empty values.
+// It returns a new map containing only labels whose keys start with any of the provided prefixes,
+// excluding any labels with empty or whitespace-only values.
+// If no prefixes are provided, returns an empty map.
+func FilterByPrefixes(in map[string]string, prefixes []string) map[string]string {
+	if len(prefixes) == 0 {
+		return make(map[string]string)
+	}
+
+	out := make(map[string]string)
+	for k, v := range in {
+		if strings.TrimSpace(v) == "" {
+			continue
+		}
+		for _, p := range prefixes {
+			if strings.HasPrefix(k, p) {
+				out[k] = v
+				break
+			}
+		}
+	}
+	return out
+}

--- a/internal/adapters/dockerlabels/filters_test.go
+++ b/internal/adapters/dockerlabels/filters_test.go
@@ -1,0 +1,73 @@
+package dockerlabels
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFilterByPrefixes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		prefixes []string
+		expected map[string]string
+	}{
+		{
+			name:     "no prefixes returns empty map",
+			input:    map[string]string{"bosun.key": "value", "other.key": "value2"},
+			prefixes: []string{},
+			expected: map[string]string{},
+		},
+		{
+			name:     "single prefix filters correctly",
+			input:    map[string]string{"bosun.key1": "value1", "bosun.key2": "value2", "other.key": "value3"},
+			prefixes: []string{"bosun."},
+			expected: map[string]string{"bosun.key1": "value1", "bosun.key2": "value2"},
+		},
+		{
+			name:     "multiple prefixes filter correctly",
+			input:    map[string]string{"bosun.key": "value1", "docker.key": "value2", "other.key": "value3"},
+			prefixes: []string{"bosun.", "docker."},
+			expected: map[string]string{"bosun.key": "value1", "docker.key": "value2"},
+		},
+		{
+			name:     "empty values are dropped",
+			input:    map[string]string{"bosun.key1": "value1", "bosun.key2": "", "bosun.key3": "value3"},
+			prefixes: []string{"bosun."},
+			expected: map[string]string{"bosun.key1": "value1", "bosun.key3": "value3"},
+		},
+		{
+			name:     "whitespace values are dropped",
+			input:    map[string]string{"bosun.key1": "value1", "bosun.key2": "   ", "bosun.key3": "\t\n"},
+			prefixes: []string{"bosun."},
+			expected: map[string]string{"bosun.key1": "value1"},
+		},
+		{
+			name:     "no matching prefixes returns empty",
+			input:    map[string]string{"bosun.key": "value", "other.key": "value2"},
+			prefixes: []string{"nomatch."},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a copy of input to verify it's not mutated
+			originalInput := make(map[string]string)
+			for k, v := range tt.input {
+				originalInput[k] = v
+			}
+
+			result := FilterByPrefixes(tt.input, tt.prefixes)
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("FilterByPrefixes() = %v, expected %v", result, tt.expected)
+			}
+
+			// Verify input map was not mutated
+			if !reflect.DeepEqual(tt.input, originalInput) {
+				t.Errorf("Input map was mutated: original %v, current %v", originalInput, tt.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implement FilterByPrefixes function to filter label maps by allowed prefixes and drop empty values, supporting selective label inclusion in Docker discovery.

Closes #21