### PR TITLE
feat(adapters/dockerlabels): implement container discovery for label discovery

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,0 @@
-# TODO
-## internal/adapters/dockerlabels/source.go
-* [internal/adapters/dockerlabels/source.go:26](internal/adapters/dockerlabels/source.go#L26): Implement full snapshot logic (#23, #24, #25) For now, return empty snapshot

--- a/internal/adapters/dockerlabels/source.go
+++ b/internal/adapters/dockerlabels/source.go
@@ -2,8 +2,10 @@ package dockerlabels
 
 import (
 	"context"
+	"strings"
 	"time"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	dlabels "github.com/simone-viozzi/bosun/internal/domain/labels"
 	"github.com/simone-viozzi/bosun/internal/ports"
@@ -21,12 +23,49 @@ func NewFromEnv() (*DockerLabelSource, error) {
 	return &DockerLabelSource{CLI: cli}, nil
 }
 
+// snapshotContainers collects containers from Docker, filters by label prefixes,
+// and returns labeled entities for containers with matching labels.
+func (s *DockerLabelSource) snapshotContainers(ctx context.Context, sel ports.Selector) ([]dlabels.LabeledEntity, error) {
+	opts := container.ListOptions{All: sel.IncludeStopped}
+	ctrs, err := s.CLI.ContainerList(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []dlabels.LabeledEntity
+	for _, c := range ctrs {
+		fl := FilterByPrefixes(c.Labels, sel.Prefixes)
+		if len(fl) == 0 {
+			continue
+		}
+		name := ""
+		if len(c.Names) > 0 {
+			name = strings.TrimPrefix(c.Names[0], "/")
+		}
+		ent := dlabels.LabeledEntity{
+			Kind:   dlabels.KindContainer,
+			ID:     c.ID,
+			Name:   name,
+			Labels: fl,
+			Meta: map[string]string{
+				"compose.project": c.Labels["com.docker.compose.project"],
+				"compose.service": c.Labels["com.docker.compose.service"],
+				"image":           c.Image,
+			},
+		}
+		out = append(out, ent)
+	}
+	return out, nil
+}
+
 // Snapshot implements the LabelSource interface
 func (d *DockerLabelSource) Snapshot(ctx context.Context, sel ports.Selector) (dlabels.Snapshot, error) {
-	// TODO: Implement full snapshot logic (#23, #24, #25)
-	//    For now, return empty snapshot
+	entities, err := d.snapshotContainers(ctx, sel)
+	if err != nil {
+		return dlabels.Snapshot{}, err
+	}
 	return dlabels.Snapshot{
-		Entities: []dlabels.LabeledEntity{},
+		Entities: entities,
 		TakenAt:  time.Now(),
 	}, nil
 }


### PR DESCRIPTION
Add snapshotContainers method to DockerLabelSource that collects containers from Docker daemon, filters labels by specified prefixes, and enriches entities with compose project/service metadata. Containers with zero matching labels are excluded. Implements Issue #23 acceptance criteria.

Closes #23